### PR TITLE
Hasan/no contention in hotpath

### DIFF
--- a/boringtun/src/device/api.rs
+++ b/boringtun/src/device/api.rs
@@ -170,7 +170,7 @@ fn api_get(writer: &mut BufWriter<&UnixStream>, d: &Device) -> i32 {
 
     for (k, peer) in d.peers.iter() {
         let (keepalive, last_handshake_time, stats) = {
-            let tun = peer.tunnel.lock();
+            let tun = &peer.tunnel;
             (
                 tun.persistent_keepalive(),
                 tun.last_handshake_time(),

--- a/boringtun/src/device/mod.rs
+++ b/boringtun/src/device/mod.rs
@@ -463,7 +463,7 @@ impl Device {
         let rate_limiter = Arc::new(RateLimiter::new(&public_key, HANDSHAKE_RATE_LIMIT));
 
         for peer in self.peers.values_mut() {
-            peer.tunnel.lock().set_static_private(
+            peer.tunnel.set_static_private(
                 private_key.clone(),
                 public_key,
                 Some(Arc::clone(&rate_limiter)),
@@ -548,7 +548,7 @@ impl Device {
                     };
 
                     let res = {
-                        let mut tun = peer.tunnel.lock();
+                        let tun = &peer.tunnel;
                         tun.update_timers(&mut t.dst_buf[..])
                     };
                     match res {
@@ -645,7 +645,7 @@ impl Device {
                     // We found a peer, use it to decapsulate the message+
                     let mut flush = false; // Are there packets to send from the queue?
                     let res = {
-                        let mut tun = peer.tunnel.lock();
+                        let tun = &peer.tunnel;
                         tun.handle_verified_packet(parsed_packet, &mut t.dst_buf[..])
                     };
                     match res {
@@ -671,7 +671,7 @@ impl Device {
                         // Flush pending queue
                         loop {
                             let res = {
-                                let mut tun = peer.tunnel.lock();
+                                let tun = &peer.tunnel;
                                 tun.decapsulate(None, &[], &mut t.dst_buf[..])
                             };
 
@@ -730,7 +730,7 @@ impl Device {
                 while let Ok(read_bytes) = udp.recv(src_buf) {
                     let mut flush = false;
                     let res = {
-                        let mut tun = peer.tunnel.lock();
+                        let tun = &peer.tunnel;
                         tun.decapsulate(
                             Some(peer_addr),
                             &t.src_buf[..read_bytes],
@@ -761,7 +761,7 @@ impl Device {
                         // Flush pending queue
                         loop {
                             let res = {
-                                let mut tun = peer.tunnel.lock();
+                                let tun = &peer.tunnel;
                                 tun.decapsulate(None, &[], &mut t.dst_buf[..])
                             };
 
@@ -828,7 +828,7 @@ impl Device {
                     };
 
                     let res = {
-                        let mut tun = peer.tunnel.lock();
+                        let tun = &peer.tunnel;
                         tun.encapsulate(src, &mut t.dst_buf[..])
                     };
                     match res {

--- a/boringtun/src/device/peer.rs
+++ b/boringtun/src/device/peer.rs
@@ -17,7 +17,7 @@ pub struct Endpoint {
 }
 
 pub struct Peer {
-    pub(crate) tunnel: Mutex<Tunn>,
+    pub(crate) tunnel: Tunn,
     /// The index the tunnel uses
     index: u32,
     endpoint: RwLock<Endpoint>,
@@ -58,7 +58,7 @@ impl Peer {
         preshared_key: Option<[u8; 32]>,
     ) -> Peer {
         Peer {
-            tunnel: Mutex::new(tunnel),
+            tunnel,
             index,
             endpoint: RwLock::new(Endpoint {
                 addr: endpoint,


### PR DESCRIPTION
Removing the locks on the tunnel so that there is no locking on the hot path by making sessions as RwLock and updating timers only in the update_timer worker.